### PR TITLE
Add EU Accessibility Mapping dataset to Data & Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ Tools and resources for neurodivergent users:
 - [Disability and Health Data System (DHDS)](https://dhds.cdc.gov/) - State-level data on adults with disabilities from the CDC.
 - [Annual Disability Statistics Collection](https://www.researchondisability.org/annual-disability-statistics-collection) - A collection of tools and reports offering over 16 years of disability statistics.
 - [The Web Almanac by HTTP Archive - Accessibility Chapter](https://almanac.httparchive.org/en/2025/accessibility) - An annual report on the state of the web, with a dedicated chapter on accessibility.
+- [EU Accessibility Mapping](https://github.com/sergordienko/eu-accessibility-mapping) - Open MIT dataset (JSON + CSV) crosswalking every WCAG 2.x A/AA success criterion to EN 301 549, the EU Accessibility Act, and Germany's BFSG, documenting the harmonized-standard chain that grants presumption of conformity.
 
 ## Automated Accessibility Tools
 


### PR DESCRIPTION
Adds a machine-readable open dataset mapping WCAG 2.x success criteria → EN 301 549 → EU Accessibility Act → German BFSG. MIT, JSON + CSV, regenerated from one script. Fits Data & Datasets; also relevant to Compliance Standards & Guidelines if you'd prefer it there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "EU Accessibility Mapping" dataset resource that provides crosswalk information linking WCAG 2.x A/AA success criteria to EU accessibility standards including EN 301 549, the EU Accessibility Act, and Germany's BFSG.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->