### PR TITLE
Add TrustYourWebsite to Automated Accessibility Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ Tools and resources for neurodivergent users:
 - [Cognixion ONE](https://www.cognixion.com/) - Wearable device that combines a brain-computer interface (BCI) with augmented reality to help individuals with severe motor impairments communicate.
 - [RatedWithAI](https://ratedwithai.com/) - Automated website accessibility scanner that checks sites for ADA and WCAG compliance issues, providing instant audits with actionable recommendations. Free scanner available.
 - [AccessCheck](https://accesscheck-app.netlify.app) – Free web accessibility scanner that runs Playwright and axe-core against any URL to identify WCAG 2.1 violations, with detailed remediation guidance and exportable reports.
+- [TrustYourWebsite](https://trustyourwebsite.com) - Automated website accessibility and compliance scanner for EU and UK small businesses, built on axe-core. Reports WCAG issues only and injects nothing into the page (not an overlay). The free scan returns a risk score and issue counts.
 
 ## Gaming Accessibility
 


### PR DESCRIPTION
Adds TrustYourWebsite to the **Automated Accessibility Tools** section.

It's an automated scanner that audits a site's accessibility (built on axe-core) alongside GDPR/cookie-banner and legal-page checks, aimed at EU and UK small businesses. It **reports issues only and injects nothing** into scanned pages, so it is not an accessibility overlay. The free tier scans any URL and returns a risk score with issue counts; paid reports add full findings and fix guidance.

Comparable in scope to RatedWithAI and AccessCheck already listed in this section. Placed at the end of the section.

Disclosure: I'm the author of the tool. Happy to adjust the wording or placement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added TrustYourWebsite to the Automated Accessibility Tools list—an EU/UK-focused accessibility and compliance scanner that identifies WCAG issues and provides risk scores with detailed issue counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->