### PR TITLE
Add Picute (free subtitle/caption tools) to Deaf & Hard of Hearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ Tools and resources for users with hearing impairments:
 - [TTY/TDD](https://www.fcc.gov/consumers/guides/telecommunications-relay-service-trs) - Text telephone devices for deaf users.
 - [Web Captioner](https://github.com/curtgrimes/webcaptioner) - Open-source real-time captioning tool (hosted service retired; source code available on GitHub).
 - [Closed Caption Creator](https://www.closedcaptioncreator.com/) - Tool for creating closed captions for videos.
+- [Picute](https://picute.net/) - AI subtitle and caption generator with free, no-signup browser tools to convert and repair subtitle files (SRT, VTT, ASS) for accessible video.
 - [Caption and Subtitles Guidelines](https://www.w3.org/WAI/media/av/captions/) - W3C guidelines for captions and subtitles.
 - [ASL Browser](https://aslbrowser.com/) - American Sign Language dictionary with video demonstrations.
 - [Merlin Hearing Aid](https://www.starkey.com/) - Starkey's hearing aid platform with fall detection, language translation, and health tracking features.


### PR DESCRIPTION
### New resource

- **Name:** Picute
- **URL:** https://picute.net/
- **Section:** Deaf and Hard of Hearing Accessibility (captioning/subtitle cluster)
- **Description:** AI subtitle and caption generator with free, no-signup, in-browser tools to convert and repair subtitle files (SRT, VTT, ASS).
- **Why it's valuable:** Captions are core to accessible video for Deaf and hard-of-hearing audiences. Picute offers free, privacy-preserving subtitle utilities (the conversions run entirely in the browser — nothing is uploaded) plus AI caption generation, sitting naturally alongside the existing captioning tools (Web Captioner, Closed Caption Creator) in this section.

Per CONTRIBUTING.md: checked for duplicates, one-sentence description, placed in the right section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new accessibility resource entry for Deaf and Hard of Hearing support.
  * Included a tool for AI-generated subtitles and captions to convert and repair subtitle files (SRT, VTT, ASS) for more accessible video.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->