### PR TITLE
Add PDF 2 EPUB (toolkit.bot) to Automated Accessibility Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Tools and resources for testing and validating accessibility:
 - [Foglift](https://foglift.io) - Free website analyzer that includes WCAG accessibility audit. Checks alt text, heading hierarchy, ARIA landmarks, keyboard navigation, color contrast, and more across all pages. Free API available.
 - [Octopus Scanner](https://lachie1999.itch.io/octopus-scanner) - Desktop accessibility auditing app using Puppeteer and axe-core. Supports full-site crawls, sitemap ingestion, interactive journey recording for authenticated flows, and deep scan engine for dynamic content. Generates interactive reports with visual defect highlighting. Free, cross-platform.
 - [PageGuard](https://pageguard.org) - Free website health scanner that checks SEO, performance, accessibility, and best practices. Generates plain-English reports. No registration required. Powered by Cloudflare Workers AI.
+- [PDF 2 EPUB (toolkit.bot)](https://toolkit.bot/pdf2epub) - Converts PDF to reflowable EPUB 3 compliant with EPUB Accessibility 1.1 and WCAG 2.2 AA, making document libraries accessible to screen readers. Required for European Accessibility Act compliance. Free web service with REST API. (Added 2026)
 
 ## Augmentative and Alternative Communication
 


### PR DESCRIPTION
## What is this?

Adds [PDF 2 EPUB (toolkit.bot)](https://toolkit.bot/pdf2epub) to the Automated Accessibility Tools section.

**toolkit.bot** converts PDF to reflowable EPUB 3 with:
- **EPUB Accessibility 1.1** (W3C specification)
- **WCAG 2.2 AA** compliance
- Screen reader compatible output
- REST API for automation
- Free web service

## Why it belongs here

Document accessibility is a critical and often overlooked a11y gap. PDFs are notoriously inaccessible to screen readers — toolkit.bot automates the conversion to accessible EPUB3 format that works with NVDA, JAWS, VoiceOver, and other assistive technologies.

With the European Accessibility Act (EAA) enforcement starting June 2026, organizations need to make their existing PDF document libraries accessible. This tool automates that at scale.

I placed it near the end of the Automated Accessibility Tools section since it is an automated conversion/remediation service rather than a test/audit tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new accessibility-testing resource entry for PDF-to-EPUB conversion, highlighting support for reflowable EPUB 3 and accessibility standards compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->