### PR TITLE
Add Vocalinux to Speech Recognition Accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ Tools and resources for voice-based interaction:
 - [Talon Voice](https://talonvoice.com/) - Hands-free computer control with voice and eye tracking.
 - [Dictation.io](https://dictation.io/) - Free online dictation tool.
 - [DailyVox](https://getdailyvox.com) - Voice-first AI diary for iPhone. On-device speech recognition works fully offline — speak instead of type. Automatic mood tracking via sentiment analysis. No data collection. ([App Store](https://apps.apple.com/app/id6760454642))
+- [Vocalinux](https://github.com/jatinkrmalik/vocalinux) - Free offline voice dictation for Linux desktops. Local speech recognition (whisper.cpp, Whisper, or VOSK) types into any app on X11 and Wayland; useful for RSI, limited typing, and privacy-sensitive workflows.
 
 ## Neurodiversity Accessibility
 


### PR DESCRIPTION
Adding Vocalinux under Speech Recognition Accessibility.

Vocalinux is free open-source offline voice dictation for Linux. It runs local models (whisper.cpp by default) and injects text into any application on X11 and Wayland. That matters for people who need hands-light typing (RSI, limited mobility) and for anyone who cannot use cloud speech services.

I'm the maintainer. Happy to adjust the blurb or section if you prefer it somewhere else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Vocalinux to the speech recognition accessibility resources, highlighting free offline voice dictation for Linux desktops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->