### PR TITLE
Add WCAG in Plain English

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Ensuring conformance to accessibility regulations:
 - [Accessibility Checker ADA Compliance for Websites](https://www.accessibilitychecker.org/guides/ada-compliance/) - A checklist for ADA website compliance.
 - [AudioEye ADA Compliance Guide](https://www.audioeye.com/compliance/ada/) - A guide to getting websites compliant with ADA digital accessibility standards.
 - [@holmdigital/standards](https://www.npmjs.com/package/@holmdigital/standards) - Machine-readable regulatory database mapping WCAG to EN 301 549 and national law across 17 jurisdictions, with typed exports and enforcement-body lookups. (MIT License)
+- [WCAG in Plain English](https://aaardvarkaccessibility.com/wcag-plain-english/) - A plain-English, beginner friendly and easy-to-use guide to WCAG.
 
 ## Assistive Technology Devices
 


### PR DESCRIPTION
Resolves the merge conflict in #28 by retaining both the existing @holmdigital/standards entry and the WCAG in Plain English entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “WCAG in Plain English” resource to the compliance standards and guidelines section, including a link and brief description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->