### PR TITLE
Add caption readability guide to deaf accessibility resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ Tools and resources for users with hearing impairments:
 - [Closed Caption Creator](https://www.closedcaptioncreator.com/) - Tool for creating closed captions for videos.
 - [Picute](https://picute.net/) - Automated subtitle and caption generator with free, no-signup browser tools to convert and repair subtitle files (SRT, VTT, ASS) for accessible video.
 - [Caption and Subtitles Guidelines](https://www.w3.org/WAI/media/av/captions/) - W3C guidelines for captions and subtitles.
+- [Caption readability check](https://timedsubs.com/en/guides/caption-readability-check) - Practical pre-publication guide for checking caption timing, overlaps, line length, reading speed, and SRT/VTT structure without presenting style thresholds as WCAG guarantees.
 - [ASL Browser](https://aslbrowser.com/) - American Sign Language dictionary with video demonstrations.
 - [Merlin Hearing Aid](https://www.starkey.com/) - Starkey's hearing aid platform with fall detection, language translation, and health tracking features.
 


### PR DESCRIPTION
## What changed

Adds the TimedSubs caption readability guide to the Deaf and Hard of Hearing Accessibility section.

## Why

The section already includes caption creation tools and the W3C caption guidelines. This guide adds a practical pre-publication review workflow covering caption timing, overlaps, line length, reading speed, and SRT/VTT structure. It explicitly distinguishes style thresholds from WCAG requirements.

## Disclosure

I maintain TimedSubs, which publishes the guide and the free browser-local subtitle checker it references.

## Checks

- Confirmed the destination returns HTTP 200.
- Checked the README and open/closed pull requests for an existing TimedSubs entry.
- Ran `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Caption readability check” resource to the Deaf and Hard of Hearing Accessibility guide.
  * The resource covers caption timing, overlaps, line length, reading speed, and SRT/VTT structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->