### PR TITLE
Add Dopastep to Cognitive Accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ Tools and resources for users with cognitive disabilities:
 - [Focusmate](https://www.focusmate.com/) - Virtual coworking platform that pairs users for live, focused work sessions using body doubling.
 - [OpenDyslexic](https://opendyslexic.org/) - Free typeface designed to increase readability for readers with dyslexia, with unique letter shapes to prevent confusion.
 - [Institute for Human Centered Design](https://humancentereddesign.org/) - Resources, consulting, and training on universal design and accessibility, focused on enhancing experiences for people of all abilities and backgrounds.
+- [Dopastep](https://dopastep.com/) - Body doubling in live focus rooms: break a task into small steps, then work alongside other people in synced focus and break cycles. No camera, chat or booking.
 
 ## Speech Recognition Accessibility
 


### PR DESCRIPTION
Adds Dopastep to the Cognitive Accessibility section.

**Disclosure: I built this, so please treat it as a suggestion rather than a neutral recommendation.** Completely fine to close this if it isn't a fit.

Following CONTRIBUTING:

- **Resource name and URL** — Dopastep, https://dopastep.com/
- **Description** — A web app for body doubling: you join a live focus room and work alongside other people in synced focus and break cycles, with no camera, no chat and no booking. It also breaks a task you've been avoiding into steps small enough that starting isn't a decision.
- **Category** — Cognitive Accessibility
- **Why it's valuable** — Task initiation is one of the executive-function barriers this section is about, and body doubling is a well-known accommodation for it. The section currently covers reading, writing, memory and mind-mapping support, but nothing addressing "I know what to do and still can't start". Dopastep needs no account to look around, which lowers the barrier for people who bounce off signup walls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Dopastep to the Cognitive Accessibility resources as a focus-room tool supporting task breakdown and synchronized work and break cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->