### PR TITLE
Add Nutilz Accessibility Checker to Accessibility Testing & Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Tools and resources for testing and validating accessibility:
 - [Octopus Scanner](https://lachie1999.itch.io/octopus-scanner) - Desktop accessibility auditing app using Puppeteer and axe-core. Supports full-site crawls, sitemap ingestion, interactive journey recording for authenticated flows, and deep scan engine for dynamic content. Generates interactive reports with visual defect highlighting. Free, cross-platform.
 - [PageGuard](https://pageguard.org) - Free website health scanner that checks SEO, performance, accessibility, and best practices. Generates plain-English reports. No registration required. Powered by Cloudflare Workers AI.
 - [PDF 2 EPUB (toolkit.bot)](https://toolkit.bot/pdf2epub) - Converts PDF to reflowable EPUB 3 compliant with EPUB Accessibility 1.1 and WCAG 2.2 AA, making document libraries accessible to screen readers. Required for European Accessibility Act compliance. Free web service with REST API. (Added 2026)
+- [Nutilz Accessibility Checker](https://nutilz.com/accessibility-checker) - Free WCAG scanner that audits any URL for critical, serious, moderate, and minor violations, gives the page a numeric score, and lists passed checks alongside per-issue fix guidance. No signup required. (Added 2026)
 
 ## Augmentative and Alternative Communication
 


### PR DESCRIPTION
Adds [Nutilz Accessibility Checker](https://nutilz.com/accessibility-checker) to the Accessibility Testing & Validation section, alongside similar free scanners like Foglift and PageGuard.

It scans any URL and reports WCAG violations grouped by impact (critical/serious/moderate/minor), gives the page a numeric score, lists passed checks, and shows per-issue fix guidance. Free, no signup required.

Placed next to the other recently-added free scanner tools in the same section, following the existing entry format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Nutilz Accessibility Checker to the accessibility testing and validation resources, including its link and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->