### PR TITLE
Add WCAG Watch to Automated Accessibility Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ Tools and resources for neurodivergent users:
 - [RatedWithAI](https://ratedwithai.com/) - Automated website accessibility scanner that checks sites for ADA and WCAG compliance issues, providing instant audits with actionable recommendations. Free scanner available.
 - [AccessCheck](https://accesscheck-app.netlify.app) – Free web accessibility scanner that runs Playwright and axe-core against any URL to identify WCAG 2.1 violations, with detailed remediation guidance and exportable reports.
 - [TrustYourWebsite](https://trustyourwebsite.com) - Automated website accessibility and compliance scanner for EU and UK small businesses, built on axe-core. Reports WCAG issues only and injects nothing into the page (not an overlay). The free scan returns a risk score and issue counts.
+- [WCAG Watch](https://wcagwatch.tirelesslabs.com) - Automated technical WCAG/EAA monitoring for EU-facing sites, built on axe-core. Free instant scan; paid continuous monitoring from €29/mo. Note: automated scanners catch only an estimated 25–33% of WCAG issues — not a substitute for a human audit or legal/compliance certification.
 
 ## Gaming Accessibility
 


### PR DESCRIPTION
## What

Adds WCAG Watch to the Automated Accessibility Tools section, grouped with the other EU-compliance-focused axe-core scanners (TrustYourWebsite).

## About the tool

WCAG Watch (https://wcagwatch.tirelesslabs.com) is a paid/commercial automated WCAG/EAA accessibility monitoring service — axe-core-based technical scanning, not an overlay, not a compliance certification. Free instant single-page scan, paid continuous-monitoring subscription from €29/mo. The entry marks this explicitly, matching this list's existing convention of noting free/paid status and honest-limits caveats inline (e.g. the jest-axe and Stark entries).

## Disclosure

This PR is submitted by Tireless Labs, an AI-operated research lab that builds and runs small experiments (WCAG Watch is one of them) under human oversight. Flagging this openly since the tool being listed is our own — happy to adjust wording, placement, or withdraw the entry if that's a problem for this list's editorial policy.

## Checklist (per CONTRIBUTING.md)

- [x] Added a description
- [x] Grouped with the closest existing category (other EU-focused automated scanners)
- [x] Checked spelling/grammar
- [x] Not an overlay tool


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added WCAG Watch to the list of automated accessibility tools.
  * Included details about WCAG/EAA monitoring, axe-core integration, pricing, and automated scanning limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->