### PR TITLE
Add A11Y.md to Specialized Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,7 @@ Tools and resources for neurodivergent users:
 - [accessibility](https://www.npmjs.com/package/accessibility) - An npm package providing an accessibility toolbar with text resizing, contrast, and link highlighting features. (MIT License)
 - [accessibility-skill](https://github.com/lukeslp/accessibility-skills) - WCAG 2.2 accessibility skill for coding agents (Claude, Codex, Cursor) with 10 audit scripts, production CSS, and JS patterns covering motor, cognitive, visual, and communication disabilities.
 - [ux-oss-safeguard](https://github.com/lukeslp/ux-oss-safeguard) - Content safety evaluator with full WCAG 2.1 AA compliance, keyboard navigation, screen reader support, and prefers-reduced-motion. Zero dependencies.
+- [A11Y.md](https://github.com/fecarrico/A11Y.md) - Persistent accessibility context standard for AI coding agents (Claude Code, Cursor, Copilot, Gemini). Portable markdown with an AI behavior contract, WCAG 2.2 AA compliance profiles, 24 lazy-loaded component guides, and versioned evidence artifacts. English and Portuguese. (MIT License)
 
 ### Automated Alt Text Tools
 


### PR DESCRIPTION
Adds [A11Y.md](https://github.com/fecarrico/A11Y.md) to Specialized Tools: a persistent accessibility context standard for AI coding agents, targeting WCAG 2.2 AA. MIT licensed, English and Portuguese.

It sits next to accessibility-skill in scope — both give coding agents accessibility context — with a different mechanism: A11Y.md is a portable markdown standard the agent's config file points at, with an AI behavior contract, compliance profiles, lazy-loaded component guides, and versioned evidence artifacts (report, exceptions, decision log).

- Not a duplicate.
- Added to Specialized Tools, following the section's existing order.
- Single line, format and license notation match neighbouring entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the A11Y resource to the README’s Specialized Tools list.
  - Describes a persistent accessibility context standard for AI coding agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->