### PR TITLE
Add YazSes to Speech Recognition Accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ Tools and resources for voice-based interaction:
 - [Dictation.io](https://dictation.io/) - Free online dictation tool.
 - [DailyVox](https://getdailyvox.com) - Voice-first diary for iPhone. On-device speech recognition works fully offline — speak instead of type. Automatic mood tracking uses sentiment analysis. No data collection. ([App Store](https://apps.apple.com/app/id6760454642))
 - [Vocalinux](https://github.com/jatinkrmalik/vocalinux) - Free offline voice dictation for Linux desktops. Local speech recognition (whisper.cpp, Whisper, or VOSK) types into any app on X11 and Wayland; useful for RSI, limited typing, and privacy-sensitive workflows.
+- [YazSes](https://github.com/MSKazemi/yazses) - Free, open-source offline dictation for Linux, macOS, and Windows. Hold-to-talk rather than always-listening, so the speaker decides when recognition starts and stops; includes a dysfluency-friendly mode intended for stuttered and dysarthric speech. Runs entirely on-device, useful for RSI and privacy-sensitive work.
 
 ## Neurodiversity Accessibility
 


### PR DESCRIPTION
Adds [YazSes](https://github.com/MSKazemi/yazses) to **Speech Recognition Accessibility**, appended after Vocalinux.

Free and open-source (Apache-2.0), runs entirely on-device — no cloud service or account — on Linux, macOS and Windows.

Two things that make it relevant to this list specifically rather than just being another dictation tool:

- **Hold-to-talk, not always-listening.** The speaker controls when recognition starts and stops. For someone whose speech includes long pauses, blocks or restarts, a VAD that decides for you cuts you off mid-word; holding a key does not.
- **A dysfluency-friendly mode** intended for stuttered and dysarthric speech, which changes how repetitions and filler are handled rather than assuming fluent input.

**Deliberate wording:** "intended for" — this is a design intent backed by ordinary software testing, **not** a clinical claim and not validated with disabled users in any formal study. Accuracy also varies by speaker and by model, as it does for every Whisper-based tool here. I would rather understate that than add to the over-promising this audience already gets.

Happy to shorten the entry if it runs long against the others.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added YazSes to the Speech Recognition Accessibility resources.
  * Documented offline, open-source dictation support for Linux, macOS, and Windows.
  * Highlighted hold-to-talk activation and dysfluency-friendly mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->