### PR TITLE
Add AAC Board AI to Augmentative and Alternative Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Tools and resources for testing and validating accessibility:
 
 Tools for facilitating communication:
 
+- [AAC Board AI](https://github.com/shayc/aac-board-ai) - Free, open-source AAC web app for symbol-based communication, with keyboard navigation, OBF/OBZ imports, multilingual interfaces, offline core features after initial load, and optional browser-provided on-device AI.
 - [Cboard](https://www.cboard.io/) - Symbol-based communication platform.
 - [MyCoughDrop](https://www.mycoughdrop.com/) - Cloud-based communication system.
 - [EyeTell](https://www.eyetell.com/) - Communication through eye-tracking technology.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ Tools and resources for testing and validating accessibility:
 
 Tools for facilitating communication:
 
-- [AAC Board AI](https://github.com/shayc/aac-board-ai) - Free, open-source AAC web app for symbol-based communication, with keyboard navigation, OBF/OBZ imports, multilingual interfaces, offline core features after initial load, and optional browser-provided on-device AI.
 - [Cboard](https://www.cboard.io/) - Symbol-based communication platform.
 - [MyCoughDrop](https://www.mycoughdrop.com/) - Cloud-based communication system.
 - [EyeTell](https://www.eyetell.com/) - Communication through eye-tracking technology.
@@ -227,6 +226,7 @@ Tools for facilitating communication:
 - [Speech and Language Kids AAC Apps](https://www.speechandlanguagekids.com/aac-apps-review/) - A review of AAC apps for children.
 - [Towson University LibGuides AAC Apps](https://towson.libguides.com/speech-language-pathology/aac-apps) - A research guide on AAC apps.
 - [Digital Scribbler 5 Must-Have AAC Apps For Adults](https://digitalscribbler.org/5-must-have-aac-apps-for-adults/) - A list of five essential AAC apps for adults.
+- [AAC Board AI](https://github.com/shayc/aac-board-ai) - Free, open-source AAC web app for symbol-based communication, with keyboard navigation, OBF/OBZ imports, multilingual interfaces, offline core features after initial load, and optional browser-provided on-device AI.
 
 ## Education & Training
 


### PR DESCRIPTION
This adds AAC Board AI to the Augmentative and Alternative Communication section.

AAC Board AI is a free, MIT-licensed, open-source AAC web app. It supports symbol-based message composition, text-to-speech, keyboard navigation, OBF/OBZ imports, multilingual interfaces, offline core features after initial load, and optional browser-provided on-device AI.

It provides a privacy-preserving, local-first browser option with Open Board Format interoperability.

I am the project maintainer. The project is not presented as clinically validated.

Repository: https://github.com/shayc/aac-board-ai
Live demo: https://aacboard.app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AAC Board AI to the list of Augmentative and Alternative Communication resources.
  * Included its website link and a brief description of its features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->