### PR TITLE
Add autism crisis communication cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,7 @@ Tools and resources for neurodivergent users:
 - [Noise-cancelling headphones](https://www.bose.com/c/headphones/noise-cancelling) - Audio equipment for sensory regulation.
 - [Stim Toy Box](https://stimtoybox.wordpress.com/) - Blog reviewing fidget and sensory tools for regulation and focus.
 - [Visual timers](https://www.timetimer.com/) - Visual countdown timers for time management support.
+- [Autism crisis communication cards](https://www.maskedbutaware.nl/en/tools/crisis-mode) - Free, phone-friendly communication support for moments when sensory overload makes speaking difficult. Available in English and Dutch without tracking; printable templates are [open source](https://github.com/maskedbutaware/autism-crisis-communication-cards).
 - [Autism Accessibility Guidelines](https://hassellinclusion.com/blog/autism-accessibility-guidelines-resource/) - Design guidance for sensory and other access needs.
 - [Animation Sensitivity Guidelines](https://source.opennews.org/articles/motion-sick/) - Designing with reduced motion to avoid triggering vestibular disorders.
 - [Focus Mode Extensions](https://chromewebstore.google.com/detail/empty-title/jgjggfakhopcciohioddgcffbecjoffg) - Browser extensions to reduce distractions.


### PR DESCRIPTION
## What this adds

Adds Autism crisis communication cards to the Neurodiversity Accessibility section. The primary resource link now points directly to the live Masked But Aware Crisis Mode. It provides phone-friendly phrases for moments when sensory overload makes speaking difficult. English and Dutch versions are available without tracking or data collection. The separate GitHub repository is included only as the open-source printable version.

## Checks

- The direct website link and both language versions load over HTTPS.
- Printable source files use an MIT license and include contribution guidance.
- The description follows the existing one-line resource format.

## Disclosure

I maintain Masked But Aware and the linked resource. I am submitting it because it fills a practical communication-access gap in the current neurodiversity section.